### PR TITLE
docs: update README with terminology consistent with the OAS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@
 
 A template for **OpenAPI Specification** projects.
 
-This project breaks the [Swagger Petsore](https://petstore.swagger.io/) example from the official documentation into smaller files. It also adds some handy commands to build, lint, and preview the OpenAPI specification from the command-line.
+This project breaks the [Swagger Petstore](https://petstore.swagger.io/) example from the official documentation into smaller files. It also adds some handy commands to build, lint, and preview the OpenAPI specification from the command-line.
 
-Either if you want to create a new OpenAPI specification from scratch or you already have it defined, you can use this template as a guide to structuring your project.
+Either if you want to create a new OpenAPI document from scratch or you already have it defined, you can use this template as a guide to structuring your project.
 
 ## Features
 
-* **Multi-file Support**: Define the OpenAPI specification in different files.
+* **Multi-file Support**: Define the OpenAPI document in different files.
 * **Merge OpenAPI files**: Merge all the separate files into one with [swagger-cli](https://github.com/APIDevTools/swagger-cli)
-* **Specification Validation**: Validate and lint the specification with [spectral](https://github.com/stoplightio/spectral)
+* **Specification Validation**: Validate and lint the OAS document with [spectral](https://github.com/stoplightio/spectral)
 * **Reference Documentation**: Generate API Reference documentation with [ReDoc](https://github.com/Redocly/redoc)
 * **GitHub Pages Support**: Publish the API Reference on [GitHub Pages](https://pages.github.com)
 
@@ -39,7 +39,7 @@ git clone https://github.com/dgarcia360/openapi-boilerplate.git
 npm install
 ```
 
-3. Edit ```openapi.yaml``` to fit your specification. If you are not familiar with the OpenAPI specification, it's worth taking a look first to the [documentation](https://swagger.io/solutions/getting-started-with-oas/).
+3. Edit ```openapi.yaml``` to fit your API definition. If you are not familiar with the OpenAPI Specification, it's worth taking a look first to the [documentation](https://swagger.io/solutions/getting-started-with-oas/).
 
 ## Useful Commands
 
@@ -51,11 +51,11 @@ The command bundles the spec as one ``.yaml`` file.
 npm run build
 ```
 
-The minified spec is stored in ``_build/openapi.yaml``.
+The minified document is stored in ``_build/openapi.yaml``.
 
 ### Test
 
-The command checks if the spec follows the OpenAPI 3.0 standard.
+The command checks if the document follows the OpenAPI 3.0 Specification.
 
 ```
 npm run test
@@ -75,9 +75,9 @@ The server starts on http://127.0.0.1:8080
 
 The project uses [GitHub Actions](https://github.com/features/actions) for Continous Integration.
 
-On every new pull request, the OpenAPI specification is linted with  [spectral](https://github.com/stoplightio/spectral). If there are changes that introduce errors, the bot will highlight them replying to the pull request.
+On every new pull request, the OpenAPI document is linted with [spectral](https://github.com/stoplightio/spectral). If there are changes that introduce errors, the bot will highlight them replying to the pull request.
 
-When the default branch (``master``) receives an update, a workflow publishes automatically the API reference documentation site to GitHub Pages. The site is generated with [ReDoc](https://github.com/Redocly/redoc).
+When the default branch (``master``) receives an update, a workflow automatically publishes the API reference documentation site to GitHub Pages. The site is generated with [ReDoc](https://github.com/Redocly/redoc).
 
 See ``.github/workflows`` to customize the available workflows. If you don't plan to use GitHub to host your spec or prefer to keep docs private, delete the ``.github`` folder.
 
@@ -90,4 +90,4 @@ If you want to enhance the boilerplate, please read [CONTRIBUTING.md](CONTRIBUTI
 
 Copyright (c) 2019-present David Garcia ([@dgarcia360](https://davidgarcia.dev)). Licensed under the [MIT License](LICENSE.md).
 
-The Pet Store example used is derived from [OAI/OpenAPI-Specification](https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v3.0/petstore.yaml), Copyright The Linux Foundation, Licensed under the [Apache License, Version 2.0](https://github.com/OAI/OpenAPI-Specification/blob/master/LICENSE).
+The PetStore example used is derived from [OAI/OpenAPI-Specification](https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v3.0/petstore.yaml), Copyright The Linux Foundation, Licensed under the [Apache License, Version 2.0](https://github.com/OAI/OpenAPI-Specification/blob/master/LICENSE).


### PR DESCRIPTION
This PR updates the README.md's terminology to reflect the usages within the OpenAPI Specification itself. A couple of other typos have been corrected.

Happy to drop any changes you don't agree with. 

Nice looking project BTW!